### PR TITLE
add strip_unit=FALSE to mipBarYearData and mipArea to avoid fails

### DIFF
--- a/R/mipArea.R
+++ b/R/mipArea.R
@@ -217,7 +217,7 @@ mipArea <- function(x, stack_priority = c("variable", "region"), total = TRUE, s
   # get the same order of colors for elements that are not defined in plotstyle.
   if (!is.factor(x[[dimToStack]])) x[[dimToStack]] <- factor(x[[dimToStack]], levels = unique(x[[dimToStack]]))
   # use plotstyle colours and labels by default
-  p <- p + scale_fill_manual(values = plotstyle(levels(x[[dimToStack]])),
+  p <- p + scale_fill_manual(values = plotstyle(levels(x[[dimToStack]]), strip_units = FALSE),
                              name   = "")
 
   # increase y-axis limits to hide all-zero data that was set to -1e-36

--- a/R/mipBarYearData.R
+++ b/R/mipBarYearData.R
@@ -98,7 +98,7 @@ mipBarYearData <- function(x, colour = NULL, ylab = NULL, xlab = NULL, title = N
   }
 
   if (is.null(colour)) {
-    colour <- plotstyle(levels(x$variable))
+    colour <- plotstyle(levels(x$variable), strip_units = FALSE)
   }
 
   # make plot


### PR DESCRIPTION
- add strip_unit=FALSE to mipBarYearData and mipArea to avoid fails
- if the unit is stripped, the color can not be mapped to the plot anymore